### PR TITLE
fix #3 misorder of running output

### DIFF
--- a/playground/sandbox.go
+++ b/playground/sandbox.go
@@ -475,7 +475,7 @@ func sandboxBuildGoplus(ctx context.Context, tmpDir string, in []byte, vet bool)
 		return br, nil
 	}
 
-	cmdBuild := exec.Command("go", "build", "-o", "a.out", "gop_autogen.go")
+	cmdBuild := exec.Command("go", "build", "-o", "a.out", "-tags=faketime", "gop_autogen.go")
 	cmdBuild.Dir = tmpDir
 	br.exePath = filepath.Join(tmpDir, "a.out")
 	cmdBuild.Stderr, cmdBuild.Stdout = out, out


### PR DESCRIPTION
fix #3 

when open tag `faketime`, the `fmt.Print` and other methods add timestamp per line ,
make the output in order.

so we open build tag `faketime` to resolve this.

